### PR TITLE
Fix typo in CEP error message

### DIFF
--- a/script.js
+++ b/script.js
@@ -4,7 +4,7 @@
         function consulta() {
             let cep = document.querySelector('#cep').value;
                 if (cep.length !== 9) {
-                    descricao.textContent= "CEP invalido"
+                    descricao.textContent= "CEP inválido"
                     return;
                 }
 


### PR DESCRIPTION
## Summary
- correct spelling of error text when CEP is invalid

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f7ad54edc8321a35b520cb2a1003a